### PR TITLE
Update for Xcode 12.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "TempleRunClone",
+    platforms: [
+        .iOS(.v14)
+    ],
+    targets: [
+        .target(
+            name: "TempleRunClone",
+            path: "Sources",
+            resources: [
+                .process("Resources")
+            ],
+            publicHeadersPath: "include"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # TempleRunClone
+
+This repository contains a simple endless runner game for iOS written in Objective-C using SpriteKit. It demonstrates core gameplay mechanics similar to games like Temple Run.
+
+## Features
+
+- Swipe left or right to change lanes
+- Swipe up to jump over obstacles
+- Increasing score over time
+- Basic game over screen with final score
+
+## Requirements
+
+- Xcode 12.4 or later
+- iOS 14 or later
+
+## Building
+
+1. Open the project in Xcode by selecting `Package.swift`.
+2. Build and run the `TempleRunClone` executable target on an iOS simulator or device.
+
+Assets can be replaced by adding images to the `Resources` directory and referencing them in the code.
+
+Header files are located in `Sources/include` for Objective-C compilation with Swift Package Manager.

--- a/Resources/README.md
+++ b/Resources/README.md
@@ -1,0 +1,1 @@
+Resources placeholder

--- a/Sources/AppDelegate.m
+++ b/Sources/AppDelegate.m
@@ -1,0 +1,13 @@
+#import "AppDelegate.h"
+#import "GameViewController.h"
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+    self.window.rootViewController = [[GameViewController alloc] init];
+    [self.window makeKeyAndVisible];
+    return YES;
+}
+
+@end

--- a/Sources/GameOverScene.m
+++ b/Sources/GameOverScene.m
@@ -1,0 +1,39 @@
+#import "GameOverScene.h"
+#import "GameScene.h"
+
+@interface GameOverScene()
+@property (nonatomic) NSInteger finalScore;
+@end
+
+@implementation GameOverScene
+
+- (instancetype)initWithSize:(CGSize)size score:(NSInteger)score {
+    if (self = [super initWithSize:size]) {
+        _finalScore = score;
+    }
+    return self;
+}
+
+- (void)didMoveToView:(SKView *)view {
+    self.backgroundColor = [UIColor blackColor];
+
+    SKLabelNode *label = [SKLabelNode labelNodeWithFontNamed:@"Avenir-Heavy"];
+    label.text = @"Game Over";
+    label.fontSize = 40;
+    label.position = CGPointMake(self.size.width/2, self.size.height/2);
+    [self addChild:label];
+
+    SKLabelNode *scoreLabel = [SKLabelNode labelNodeWithFontNamed:@"Avenir-Heavy"];
+    scoreLabel.text = [NSString stringWithFormat:@"Score: %ld", (long)self.finalScore];
+    scoreLabel.fontSize = 24;
+    scoreLabel.position = CGPointMake(self.size.width/2, self.size.height/2 - 60);
+    [self addChild:scoreLabel];
+}
+
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    GameScene *scene = [[GameScene alloc] initWithSize:self.size];
+    scene.scaleMode = self.scaleMode;
+    [self.view presentScene:scene transition:[SKTransition flipHorizontalWithDuration:0.5]];
+}
+
+@end

--- a/Sources/GameScene.m
+++ b/Sources/GameScene.m
@@ -1,0 +1,113 @@
+#import "GameScene.h"
+#import "PlayerNode.h"
+#import "ObstacleNode.h"
+#import "GameOverScene.h"
+
+@interface GameScene()
+@property (nonatomic, strong) PlayerNode *player;
+@property (nonatomic, strong) NSArray<NSNumber *> *lanes;
+@property (nonatomic) NSInteger currentLaneIndex;
+@property (nonatomic, strong) SKLabelNode *scoreLabel;
+@property (nonatomic) NSInteger score;
+@property (nonatomic) NSTimeInterval lastSpawnTime;
+@end
+
+@implementation GameScene
+
+- (instancetype)initWithSize:(CGSize)size {
+    if (self = [super initWithSize:size]) {
+        _player = [[PlayerNode alloc] init];
+        _lanes = @[];
+        _currentLaneIndex = 1;
+        _scoreLabel = [SKLabelNode labelNodeWithFontNamed:@"Avenir-Heavy"];
+        _score = 0;
+        _lastSpawnTime = 0;
+    }
+    return self;
+}
+
+- (void)didMoveToView:(SKView *)view {
+    self.backgroundColor = [UIColor blackColor];
+    self.physicsWorld.gravity = CGVectorMake(0, -9.8);
+    self.physicsWorld.contactDelegate = self;
+
+    CGFloat laneWidth = self.size.width / 3.0;
+    self.lanes = @[@(laneWidth * 0.5), @(laneWidth * 1.5), @(laneWidth * 2.5)];
+
+    self.player.position = CGPointMake([self.lanes[self.currentLaneIndex] floatValue], 120);
+    [self addChild:self.player];
+
+    self.scoreLabel.fontSize = 24;
+    self.scoreLabel.position = CGPointMake(20, self.size.height - 40);
+    self.scoreLabel.horizontalAlignmentMode = SKLabelHorizontalAlignmentModeLeft;
+    [self addChild:self.scoreLabel];
+    [self updateScoreLabel];
+}
+
+- (void)spawnObstacle {
+    ObstacleNode *obstacle = [[ObstacleNode alloc] initWithSize:CGSizeMake(40, 40)];
+    NSNumber *laneX = [self.lanes objectAtIndex:arc4random_uniform((uint32_t)self.lanes.count)];
+    obstacle.position = CGPointMake([laneX floatValue], self.size.height + obstacle.size.height);
+    [self addChild:obstacle];
+
+    SKAction *move = [SKAction moveByX:0 y:-self.size.height - obstacle.size.height * 2 duration:4.0];
+    SKAction *remove = [SKAction removeFromParent];
+    [obstacle runAction:[SKAction sequence:@[move, remove]]];
+}
+
+- (void)updateScoreLabel {
+    self.scoreLabel.text = [NSString stringWithFormat:@"Score: %ld", (long)self.score];
+}
+
+- (void)moveLaneWithDirection:(NSInteger)direction {
+    NSInteger newIndex = MAX(0, MIN(self.lanes.count - 1, self.currentLaneIndex + direction));
+    if (newIndex != self.currentLaneIndex) {
+        self.currentLaneIndex = newIndex;
+        SKAction *action = [SKAction moveToX:[self.lanes[self.currentLaneIndex] floatValue] duration:0.2];
+        [self.player runAction:action];
+    }
+}
+
+- (void)jump {
+    [self.player jump];
+}
+
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    UITouch *touch = [touches anyObject];
+    if (!touch) return;
+    CGPoint location = [touch locationInNode:self];
+    CGPoint previous = [touch previousLocationInNode:self];
+    CGFloat dx = location.x - previous.x;
+    CGFloat dy = location.y - previous.y;
+
+    if (fabs(dx) > fabs(dy)) {
+        if (dx > 0) {
+            [self moveLaneWithDirection:1];
+        } else {
+            [self moveLaneWithDirection:-1];
+        }
+    } else {
+        if (dy > 0) {
+            [self jump];
+        }
+    }
+}
+
+- (void)update:(NSTimeInterval)currentTime {
+    if (currentTime - self.lastSpawnTime > 1.5) {
+        [self spawnObstacle];
+        self.lastSpawnTime = currentTime;
+    }
+    self.score += 1;
+    [self updateScoreLabel];
+}
+
+- (void)didBeginContact:(SKPhysicsContact *)contact {
+    if (contact.bodyA.categoryBitMask == PhysicsCategoryObstacle ||
+        contact.bodyB.categoryBitMask == PhysicsCategoryObstacle) {
+        GameOverScene *gameOver = [[GameOverScene alloc] initWithSize:self.size score:self.score];
+        [self.view presentScene:gameOver transition:[SKTransition crossFadeWithDuration:0.5]];
+    }
+}
+
+@end

--- a/Sources/GameViewController.m
+++ b/Sources/GameViewController.m
@@ -1,0 +1,22 @@
+#import "GameViewController.h"
+#import <SpriteKit/SpriteKit.h>
+#import "GameScene.h"
+
+@implementation GameViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    SKView *skView = [[SKView alloc] initWithFrame:self.view.bounds];
+    skView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    [self.view addSubview:skView];
+
+    GameScene *scene = [[GameScene alloc] initWithSize:self.view.bounds.size];
+    scene.scaleMode = SKSceneScaleModeResizeFill;
+    [skView presentScene:scene];
+}
+
+- (BOOL)prefersStatusBarHidden {
+    return YES;
+}
+
+@end

--- a/Sources/ObstacleNode.m
+++ b/Sources/ObstacleNode.m
@@ -1,0 +1,29 @@
+#import "ObstacleNode.h"
+#import "PlayerNode.h"
+
+@implementation ObstacleNode
+
+- (instancetype)initWithSize:(CGSize)size {
+    if (self = [super initWithTexture:nil color:[UIColor redColor] size:size]) {
+        [self setupPhysics:size];
+    }
+    return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)coder {
+    self = [super initWithCoder:coder];
+    if (self) {
+        [self setupPhysics:CGSizeMake(40, 40)];
+    }
+    return self;
+}
+
+- (void)setupPhysics:(CGSize)size {
+    self.physicsBody = [SKPhysicsBody bodyWithRectangleOfSize:size];
+    self.physicsBody.dynamic = NO;
+    self.physicsBody.categoryBitMask = PhysicsCategoryObstacle;
+    self.physicsBody.contactTestBitMask = PhysicsCategoryPlayer;
+    self.physicsBody.collisionBitMask = 0;
+}
+
+@end

--- a/Sources/PlayerNode.m
+++ b/Sources/PlayerNode.m
@@ -1,0 +1,39 @@
+#import "PlayerNode.h"
+
+const uint32_t PhysicsCategoryPlayer = 1 << 0;
+const uint32_t PhysicsCategoryObstacle = 1 << 1;
+
+@implementation PlayerNode
+
+- (instancetype)init {
+    SKTexture *texture = [SKTexture textureWithImageNamed:@"player"];
+    if (self = [super initWithTexture:texture color:[UIColor clearColor] size:CGSizeMake(50, 80)]) {
+        [self setupPhysics];
+    }
+    return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)coder {
+    self = [super initWithCoder:coder];
+    if (self) {
+        [self setupPhysics];
+    }
+    return self;
+}
+
+- (void)setupPhysics {
+    self.physicsBody = [SKPhysicsBody bodyWithRectangleOfSize:CGSizeMake(50, 80)];
+    self.physicsBody.dynamic = YES;
+    self.physicsBody.allowsRotation = NO;
+    self.physicsBody.categoryBitMask = PhysicsCategoryPlayer;
+    self.physicsBody.contactTestBitMask = PhysicsCategoryObstacle;
+    self.physicsBody.collisionBitMask = 0;
+}
+
+- (void)jump {
+    if (self.physicsBody.velocity.dy == 0) {
+        [self.physicsBody applyImpulse:CGVectorMake(0, 400)];
+    }
+}
+
+@end

--- a/Sources/include/AppDelegate.h
+++ b/Sources/include/AppDelegate.h
@@ -1,0 +1,5 @@
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+@property (strong, nonatomic) UIWindow *window;
+@end

--- a/Sources/include/GameOverScene.h
+++ b/Sources/include/GameOverScene.h
@@ -1,0 +1,5 @@
+#import <SpriteKit/SpriteKit.h>
+
+@interface GameOverScene : SKScene
+- (instancetype)initWithSize:(CGSize)size score:(NSInteger)score;
+@end

--- a/Sources/include/GameScene.h
+++ b/Sources/include/GameScene.h
@@ -1,0 +1,4 @@
+#import <SpriteKit/SpriteKit.h>
+
+@interface GameScene : SKScene <SKPhysicsContactDelegate>
+@end

--- a/Sources/include/GameViewController.h
+++ b/Sources/include/GameViewController.h
@@ -1,0 +1,4 @@
+#import <UIKit/UIKit.h>
+
+@interface GameViewController : UIViewController
+@end

--- a/Sources/include/ObstacleNode.h
+++ b/Sources/include/ObstacleNode.h
@@ -1,0 +1,5 @@
+#import <SpriteKit/SpriteKit.h>
+
+@interface ObstacleNode : SKSpriteNode
+- (instancetype)initWithSize:(CGSize)size;
+@end

--- a/Sources/include/PlayerNode.h
+++ b/Sources/include/PlayerNode.h
@@ -1,0 +1,8 @@
+#import <SpriteKit/SpriteKit.h>
+
+extern const uint32_t PhysicsCategoryPlayer;
+extern const uint32_t PhysicsCategoryObstacle;
+
+@interface PlayerNode : SKSpriteNode
+- (void)jump;
+@end

--- a/Sources/main.m
+++ b/Sources/main.m
@@ -1,0 +1,8 @@
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}


### PR DESCRIPTION
## Summary
- relax requirements for older tooling
- move resources before headers in package definition
- use traditional `.target` for Swift 5.3 compatibility

## Testing
- `swift build` *(fails: SpriteKit/UIKit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684def77631c83329268e22693e8e25b