### PR TITLE
Update AppDelegate header for macOS compatibility

### DIFF
--- a/Sources/include/AppDelegate.h
+++ b/Sources/include/AppDelegate.h
@@ -1,4 +1,7 @@
+#import <TargetConditionals.h>
+#if !TARGET_OS_OSX
 #import <UIKit/UIKit.h>
+#endif
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 @property (strong, nonatomic) UIWindow *window;

--- a/Sources/include/GameViewController.h
+++ b/Sources/include/GameViewController.h
@@ -1,4 +1,7 @@
+#import <TargetConditionals.h>
+#if !TARGET_OS_OSX
 #import <UIKit/UIKit.h>
+#endif
 
 @interface GameViewController : UIViewController
 @end


### PR DESCRIPTION
## Summary
- wrap `UIKit` import with `TargetConditionals` check in `AppDelegate.h`
- do the same for `GameViewController.h`

## Testing
- `swift build -c release` *(fails: system iOS frameworks not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dfcefd66c83329d3f7aa8338deb6e